### PR TITLE
Don't ignore fatal errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,12 @@ function createReadStream( config ){
   // print error and exit on stderr
   proc.stderr.on( 'data', errorHandler( 'pbf2json' ) );
 
+  proc.on('close', function checkErr(code) {
+    if (code !== 0) {
+      process.exit(code);
+    }
+  });
+
   // terminate the process and pipeline
   decoder.kill = function(){
     proc.kill();

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "pre-commit": [
     "lint",
     "validate",
-    "test",
-    "check-dependencies"
+    "test"
   ]
 }


### PR DESCRIPTION
Parser did not care about data format, corruption or any kind of error
in the spawned child process. Parser always happily
returned success exit code with zero parsed items.