### PR TITLE
DT-3837

### DIFF
--- a/pbf2json.go
+++ b/pbf2json.go
@@ -509,7 +509,8 @@ func outputValidEntries(context *context) {
         printJson(water)
     }
     for _, entrance := range context.entrances {
-        printJson(entrance)
+        translateAddress(entrance.Tags, &Point{entrance.Lat, entrance.Lon}, context)
+	printJson(entrance)
         // logJson(entrance)
     }
 }

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -609,9 +609,6 @@ func entranceLookup(db *leveldb.DB, way *osmpbf.Way, street string, housenumber 
         if street != "" { // parent entity has valid street address
             _, hasStreet := node.Tags["addr:street"]
             _, hasNumber := node.Tags["addr:housenumber"]
-            if hasStreet && hasNumber {
-               continue // already valid address entity, do nothing
-            }
             ref, hasRef := validateUnit(node.Tags, "ref")
             if !hasRef {
                ref, hasRef = validateUnit(node.Tags, "addr:unit")

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -609,6 +609,9 @@ func entranceLookup(db *leveldb.DB, way *osmpbf.Way, street string, housenumber 
         if street != "" { // parent entity has valid street address
             _, hasStreet := node.Tags["addr:street"]
             _, hasNumber := node.Tags["addr:housenumber"]
+            if hasStreet && hasNumber {
+               continue // already valid address entity, do nothing
+            }
             ref, hasRef := validateUnit(node.Tags, "ref")
             if !hasRef {
                ref, hasRef = validateUnit(node.Tags, "addr:unit")

--- a/pbf2json.go
+++ b/pbf2json.go
@@ -609,16 +609,17 @@ func entranceLookup(db *leveldb.DB, way *osmpbf.Way, street string, housenumber 
         if street != "" { // parent entity has valid street address
             _, hasStreet := node.Tags["addr:street"]
             _, hasNumber := node.Tags["addr:housenumber"]
-            if hasStreet && hasNumber {
-               continue // already valid address entity, do nothing
-            }
             ref, hasRef := validateUnit(node.Tags, "ref")
             if !hasRef {
                ref, hasRef = validateUnit(node.Tags, "addr:unit")
             }
             if hasRef {
-              node.Tags["addr:street"] = street // add missing addr info
-              node.Tags["addr:housenumber"] = housenumber
+	      if !hasStreet {
+	          node.Tags["addr:street"] = street // add missing addr info
+              }
+	      if !hasNumber {
+	          node.Tags["addr:housenumber"] = housenumber
+              }
               node.Tags["addr:unit"] = ref // use addr:unit to pass staircase/entrance
               context.entrances[node.ID] = node
             }


### PR DESCRIPTION
- Waterways are now processed the same way as highways: adjacent segments are merged into one. Importer extracted 75 Vantaanjoki items before, now only one.
-  Ref tag associated with address ways and nodes (or sub nodes of ways with address) is now parsed more carefully. More documents get exact address of form 'street number unit'. 
- Entrance address points are now translated using street name dictionary